### PR TITLE
Add all maps parameter

### DIFF
--- a/magicked_admin/chatbot/commands/server_commands.py
+++ b/magicked_admin/chatbot/commands/server_commands.py
@@ -115,6 +115,10 @@ class CommandGameMaps(Command):
         Command.__init__(self, server, admin_only=False, requires_patch=False)
 
         self.help_text = "game maps help text"
+        self.parser.add_argument(
+            "-a", "--all",
+            action="store_true"
+        )
 
     def execute(self, username, args, user_flags):
         args, err = self.parse_args(username, args, user_flags)
@@ -123,7 +127,7 @@ class CommandGameMaps(Command):
         elif args.help:
             return self.format_response(self.help_text, args)
 
-        message = ", ".join(self.server.get_maps())
+        message = ", ".join(self.server.get_maps(not args.all))
 
         return self.format_response(message, args)
 

--- a/magicked_admin/server/server.py
+++ b/magicked_admin/server/server.py
@@ -110,7 +110,10 @@ class Server:
             self.web_admin.set_game_password(self.game_password)
 
     def get_maps(self, active_only=False):
-        return self.web_admin.get_maps()
+        if active_only:
+            return self.web_admin.get_active_maps()
+        else:
+            return self.web_admin.get_maps()
 
     def find_map(self, search_title):
         matches = 0

--- a/magicked_admin/web_admin/web_admin.py
+++ b/magicked_admin/web_admin/web_admin.py
@@ -119,7 +119,18 @@ class WebAdmin(object):
         maplist_tree = html.fromstring(response.content)
 
         available_path = "//textarea[@id='allmaps']/text()"
-        return maplist_tree.xpath(available_path)[0].split('\n')
+        maps = maplist_tree.xpath(available_path)[0].split('\n')
+
+        return maps
+
+    def get_active_maps(self):
+        response = self.__web_interface.get_maplist()
+        maplist_tree = html.fromstring(response.content)
+
+        mapcycle_path = "//textarea[@id='mapcycle']/text()"
+        maps = maplist_tree.xpath(mapcycle_path)[0].split('\n')
+
+        return maps
 
     def set_server_name(self, name):
         self.set_general_setting("settings_ServerName", name)


### PR DESCRIPTION
# Description

Adds a new parameter to `!maps`, `--all`. Default behavior is now to display only maps in-cycle.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Follows the style guidelines of this project
- [x] Corresponding changes to the documentation
- [x] Generates no new warnings
- [x] Linter passes
