### PR TITLE
Can now use admin_patches from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3
 
 COPY magicked_admin /magicked_admin
+COPY docker_startup.sh /magicked_admin/docker_startup.sh
+COPY admin_patches /magicked_admin_patches
 COPY requirements.txt /magicked_admin/requirements.txt
 
 RUN pip install -r /magicked_admin/requirements.txt
 
 WORKDIR /magicked_admin
 
-CMD [ "python", "magicked_admin.py", "-s"]
+CMD ["/magicked_admin/docker_startup.sh"]

--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ After this command runs the container will exit out and the logs will tell you
 to setup the config file. Go to your `conf` folder and set things up then run 
 the container again and you are good to go!
 
+If you want to use the admin_patches so that kf-magicked-admin gets installed into your server directory when the container starts (some gamemodes wont track stats without it) just mount your game directory into the container and set the `PATCHES_TARGET_DIR` env variable to the directory. You can mount multiple directories and just separate them with a comma "," in the env variable if you have many servers. Here is an example:
+```
+    docker run -it -p 1880:1880 --name kf2-magicked-admin -v '<host config folder location>':'/magicked_admin/conf' -v '<host kf folder>':/kf2-server -v '<host kf folder>':/kf2-server-two -e 'PATCHES_TARGET_DIR'='/kf2-server,/kf2-server-two' th3z/kf2-magicked-admin
+```
+
 Running from Python sources
 ---------------------------
 

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# this script runs inside the docker container
+# it's purpose is to run admin_patches on the server directories
+
+if [[ ! -z "$PATCHES_TARGET_DIR" ]]
+then
+	cd /magicked_admin_patches
+	for i in $(echo $PATCHES_TARGET_DIR | sed "s/,/ /g")
+	do
+		echo "*** Applying admin_patches to $i ***"
+	    echo $'\n'
+	    python ./admin_patches.py -t "$i"
+	    echo $'\n\n'
+	done
+	echo $'*** Done applying admin_patches ***\n'
+fi
+
+cd /magicked_admin
+python /magicked_admin/magicked_admin.py -s


### PR DESCRIPTION
# Description

admin_patches can now be used with docker containers by mounting the kf2 server folder to the container and setting `PATCHES_TARGET_DIR` to the mounted directory. This new variable accepts a comma separated list so multiple directories can be updated at once.

(This isn't associated with an issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] Follows the style guidelines of this project
- [x] Corresponding changes to the documentation and help texts
- [ ] Updated relevant locale files `make i18n-init`
- [ ] Added tests
- [x] Pytests and linter passes
- [x] Added relevant labels to the pull request
- [x] I agree to these changes being released under the terms of the MIT license
